### PR TITLE
Spacing between Width and Height

### DIFF
--- a/lib/octopress-video-tag.rb
+++ b/lib/octopress-video-tag.rb
@@ -61,7 +61,7 @@ module Octopress
 
         def sizes
           s = @markup.scan(Size).flatten.compact
-          attrs = "width='#{s[0]}'" if s[0]
+          attrs = "width='#{s[0]}' " if s[0]
           attrs += "height='#{s[1]}'" if s[1]
           attrs
         end


### PR DESCRIPTION
When testing the video tag, my source code did not display correctly when width and hight was entered.  I believe it's missing a space as this was displayed on Safari as seen on this screenshot: http://cl.ly/image/3k0H1i1x2l2M 

``` bash
video class=’featured wide’ controls poster=’http://resources.jamfsoftware.com/_images/sized/JNUC-2014-Policies-101_750_422_84_1414611334.jpeg’ width=’750px’height=’422px’ preload=’metadata’ onclick=’(function(el){ if(el.paused) el.play(); else el.pause() })(this)’></video>
```